### PR TITLE
fix: Added qwt6 path for OpenSuse repo install

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,9 @@ https://hackaday.io/project/5334-serialplot-realtime-plotting-software
 Under Ubuntu/Debian:
 ```apt install qtbase5-dev libqt5serialport5-dev cmake mercurial```
 
+Under OpenSUSE:
+```zypper in libqt5-qtbase-devel libqt5-qtserialbus-devel libqt5-qtserialport-devel cmake mercurial```
+
 ### Download and Install Qwt [Optional]
 
 [Qwt](http://qwt.sourceforge.net) is the library that provides
@@ -48,8 +51,9 @@ plotting widgets for SerialPlot. You have 3 different options for Qwt.
 
 * Leave it to serialplot build scripts. Qwt will be downloaded and built for you.
 
-* If your linux distribution has `libqwt-qt5-dev` or `qwt-qt5-devel`
-  package, install it and set `BUILD_QWT` cmake option to `false`.
+* If your linux distribution has the `libqwt-qt5-dev` or `qwt-qt5-devel` or,
+  on OpenSUSE, `qwt6-qt5-devel` package, 
+  install it and set `BUILD_QWT` cmake option to `false`.
 
 * Download Qwt 6 [here](http://sourceforge.net/projects/qwt/files/)
   and build it yourself per these

--- a/cmake/modules/FindQwt.cmake
+++ b/cmake/modules/FindQwt.cmake
@@ -124,7 +124,6 @@ if (QWT_LIBRARY AND (NOT qwt_is_static))
     LIST_PREREQUISITES(${QWT_LIBRARY})
   endif()
 endif (QWT_LIBRARY AND (NOT qwt_is_static))
-#endif (QWT_LIBRARY)
 
 # set QWT_FOUND
 if(QWT_INCLUDE_DIR AND QWT_LIBRARY AND (qwt_is_static OR qwt_is_qt5))

--- a/cmake/modules/FindQwt.cmake
+++ b/cmake/modules/FindQwt.cmake
@@ -69,7 +69,7 @@ if(QWT_ROOT)
   find_library(QWT_LIBRARY NAMES "qwt-qt5" "qwt" PATHS "${QWT_ROOT}/lib")
 else (QWT_ROOT)
   ## Look into system locations
-  find_path(QWT_INCLUDE_DIR qwt_plot.h PATHS /usr/include/qwt)
+  find_path(QWT_INCLUDE_DIR qwt_plot.h PATHS /usr/include/qwt /usr/include/qwt6)
   # try extracting version information
   if (QWT_INCLUDE_DIR)
 	unset(qwt_version_string)
@@ -123,7 +123,8 @@ if (QWT_LIBRARY AND (NOT qwt_is_static))
     message(WARNING "Found qwt library (${QWT_LIBRARY}) isn't compiled with Qt5!")
     LIST_PREREQUISITES(${QWT_LIBRARY})
   endif()
-endif (QWT_LIBRARY)
+endif (QWT_LIBRARY AND (NOT qwt_is_static))
+#endif (QWT_LIBRARY)
 
 # set QWT_FOUND
 if(QWT_INCLUDE_DIR AND QWT_LIBRARY AND (qwt_is_static OR qwt_is_qt5))


### PR DESCRIPTION
In OpenSuse Leap 15.2 (and maybe others), the qwt6 header files
installed via zypper are located in /usr/include/qwt6

I also got a warning about if-endif mismatch, so I did a quick change there.

Not included in this pull request, but one could add the required packages available from the OpenSuse repository to the Readme. While maybe not minimal, I used `libqt5-qtbase-devel qwt6-devel qwt6-qt5-devel libqt5-qtserialbus-devel libqt5-qtserialport-devel` with zypper.