### PR TITLE
Allow Arduino Serial Plotter style ascii data

### DIFF
--- a/src/asciireader.cpp
+++ b/src/asciireader.cpp
@@ -163,6 +163,7 @@ unsigned AsciiReader::readData()
 SamplePack* AsciiReader::parseLine(const QString& line) const
 {
     auto separatedValues = line.split(delimiter, QString::SkipEmptyParts);
+    QString strippedValue;
     unsigned numComingChannels = separatedValues.length();
 
     // check number of channels (skipped if auto num channels is enabled)
@@ -177,17 +178,18 @@ SamplePack* AsciiReader::parseLine(const QString& line) const
     auto samples = new SamplePack(1, numComingChannels);
     for (unsigned ci = 0; ci < numComingChannels; ci++)
     {
+	strippedValue = separatedValues[ci].split(':', QString::SkipEmptyParts).back();
         bool ok;
         if (isHexData)
         {
-            samples->data(ci)[0] = separatedValues[ci].toInt(&ok,16);
+            samples->data(ci)[0] = strippedValue.toInt(&ok,16);
         }
         else
         {
-            samples->data(ci)[0] = separatedValues[ci].toDouble(&ok);
+            samples->data(ci)[0] = strippedValue.toDouble(&ok);
             if (!ok)
             {
-                samples->data(ci)[0] = separatedValues[ci].toInt(&ok,0);
+                samples->data(ci)[0] = strippedValue.toInt(&ok,0);
             }
         }
         if (!ok)


### PR DESCRIPTION
The built-in [Arduino Serial Plotter](https://docs.arduino.cc/software/ide-v2/tutorials/ide-v2-serial-plotter) accepts labels inline with the data in a format of:

```
label1:data1,label2:data2,label3:data3
```

This PR strips these labels out allowing the data values to be parsed normally. This does not impact ascii data of the usual form:

```
data1,data2,data3,data4
```

Conceivably the labels could be added to the ChannelInfo in the future. 