### PR TITLE
Migrate docker to buildx & fix build dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,7 @@
-FROM ubuntu:bionic
+FROM ubuntu:bionic AS builder
 
 # Install build dependencies
-RUN apt-get update
-RUN apt-get -y install software-properties-common
-RUN add-apt-repository -y ppa:beineri/opt-qt-5.15.2-bionic
-RUN apt-get -y install build-essential mesa-common-dev qt515base qt515serialport qt515svg cmake mercurial subversion git wget libfuse2
+RUN apt-get update && apt-get install -y software-properties-common && add-apt-repository -y ppa:beineri/opt-qt-5.15.2-bionic && apt-get install -y build-essential mesa-common-dev qt515base qt515serialport qt515svg cmake mercurial subversion git wget libfuse2 libgl1-mesa-dev
 
 # Define environment variable
 ENV PATH /opt/qt515/bin/:$PATH
@@ -13,3 +10,6 @@ WORKDIR /serialplot
 ADD . /serialplot
 WORKDIR ./build_docker
 RUN cmake ../ && make -j appimage
+
+FROM scratch as exporter
+COPY --from=builder /serialplot/build_docker/SerialPlot*.AppImage /


### PR DESCRIPTION
Migrates the dockerfile to [buildx](https://docs.docker.com/engine/reference/commandline/buildx/).

This allows `docker buildx build -o . .` to directly copy the AppImage into the local directory, ie:

```
$ docker buildx build -o . .
$ ls
...  README.md  SerialPlot-dc93651-x86_64.AppImage  serialplot.pro  ...
```

This PR also migrates all of the `apt` commands into one docker layer so a cached `apt-get update` layer does not prevent the subsequent  `apt-get install`s  from breaking due to old information. 

Additionally, `libgl1-mesa-dev` is required to build the QWT.