### PR TITLE
Implement multi-character delimiter

### DIFF
--- a/src/asciireader.cpp
+++ b/src/asciireader.cpp
@@ -48,7 +48,7 @@ AsciiReader::AsciiReader(QIODevice* device, QObject* parent) :
             });
 
     connect(&_settingsWidget, &AsciiReaderSettings::delimiterChanged,
-            [this](QChar d)
+            [this](QString d)
             {
                 delimiter = d;
             });

--- a/src/asciireader.h
+++ b/src/asciireader.h
@@ -46,7 +46,7 @@ private:
     unsigned _numChannels;
     /// number of channels will be determined from incoming data
     unsigned autoNumOfChannels;
-    QChar delimiter; ///< selected column delimiter
+    QString delimiter; ///< selected column delimiter
     bool isHexData; ///< use hex encoding instead of decimal
     AsciiReaderSettings::FilterMode filterMode;
     QString filterPrefix; ///< selected ASCII mode filter prefix

--- a/src/asciireadersettings.cpp
+++ b/src/asciireadersettings.cpp
@@ -33,7 +33,7 @@ AsciiReaderSettings::AsciiReaderSettings(QWidget *parent) :
 {
     ui->setupUi(this);
 
-    auto validator = new QRegularExpressionValidator(QRegularExpression("[^\\d]?"), this);
+    auto validator = new QRegularExpressionValidator(QRegularExpression("[^\\d]*"), this);
     ui->leDelimiter->setValidator(validator);
 
     ui->spNumOfChannels->setMaximum(MAX_NUM_CHANNELS);
@@ -104,7 +104,7 @@ AsciiReaderSettings::FilterMode AsciiReaderSettings::filterMode() const
     return static_cast<FilterMode>(filterButtons.checkedId());
 }
 
-QChar AsciiReaderSettings::delimiter() const
+QString AsciiReaderSettings::delimiter() const
 {
     if (ui->rbComma->isChecked())
     {
@@ -120,8 +120,7 @@ QChar AsciiReaderSettings::delimiter() const
     }
     else                        // rbOther
     {
-        auto t = ui->leDelimiter->text();
-        return t.isEmpty() ? QChar() : t.at(0);
+        return ui->leDelimiter->text();
     }
 }
 
@@ -145,7 +144,7 @@ void AsciiReaderSettings::customDelimiterChanged(const QString text)
 {
     if (ui->rbOtherDelimiter->isChecked())
     {
-        if (!text.isEmpty()) emit delimiterChanged(text.at(0));
+        if (!text.isEmpty()) emit delimiterChanged(text);
     }
 }
 

--- a/src/asciireadersettings.h
+++ b/src/asciireadersettings.h
@@ -44,7 +44,7 @@ public:
     ~AsciiReaderSettings();
 
     unsigned numOfChannels() const;
-    QChar delimiter() const;
+    QString delimiter() const;
     bool isHex() const;
     /// Stores settings into a `QSettings`
     void saveSettings(QSettings* settings);
@@ -54,7 +54,7 @@ public:
 signals:
     void numOfChannelsChanged(unsigned);
     /// Signaled only with a valid delimiter
-    void delimiterChanged(QChar);
+    void delimiterChanged(QString);
     void hexChanged(bool);
     void filterChanged(FilterMode, QString);
 


### PR DESCRIPTION
Thanks for this valuable piece of software!

Since QString.split supports QString as a delimiter, it is straight-forward to allow multi-character delimiters. 

In this PR I have replaced the QChar delimiter with QString and hence close #68 