### PR TITLE
Add colon/semicolon/auto delimiters and Arduino label auto-detection (#82)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,7 +19,7 @@
 
 cmake_minimum_required(VERSION 3.16)
 
-project(serialplot VERSION 0.12.0 LANGUAGES CXX)
+project(serialplot VERSION 0.12.1 LANGUAGES CXX)
 
 set(PROGRAM_NAME ${CMAKE_PROJECT_NAME} CACHE STRING "Output program name")
 set(PROGRAM_DISPLAY_NAME "SerialPlot" CACHE STRING "Display name (menus etc) of the program")
@@ -89,6 +89,7 @@ qt_add_executable(${PROGRAM_NAME}
   src/framebufferseries.cpp
   src/numberformatbox.cpp
   src/endiannessbox.cpp
+  src/udpcontrol.cpp
   src/abstractreader.cpp
   src/binarystreamreader.cpp
   src/binarystreamreadersettings.cpp

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -119,6 +119,74 @@ serialplot automatically detects `key:value` pairs and uses the keys as channel 
 
 ---
 
+## Building a Windows installer
+
+Requires MSYS2 + NSIS (installed automatically by the script).
+
+```powershell
+.\build_windows.ps1 -Install -Package
+```
+
+Output: `build-windows\serialplot-<version>-win64.exe`
+
+The `-Package` flag installs `mingw-w64-ucrt-x86_64-nsis` via pacman and runs `cpack -G NSIS`.
+
+---
+
+## Publishing a GitHub release
+
+Requires the [GitHub CLI](https://cli.github.com/) (`gh`). Install via:
+
+```powershell
+winget install --id GitHub.cli
+gh auth login
+```
+
+### Tag the source commit
+
+```powershell
+git tag -a "serialplot-<version>" -m "serialplot <version>"
+git push origin "serialplot-<version>"
+```
+
+### Create the release and upload the installer
+
+```powershell
+gh release create "serialplot-<version>" "build-windows\serialplot-<version>-win64.exe" `
+  --repo "RolandWa/serialplot" `
+  --title "v<version> — <short description>" `
+  --notes "Release notes here"
+```
+
+Releases are published at: [github.com/RolandWa/serialplot/releases](https://github.com/RolandWa/serialplot/releases)
+
+---
+
+## Ubuntu build (WSL)
+
+Use WSL with Ubuntu. The original project's packaging scripts work as-is.
+
+```bash
+# Inside WSL Ubuntu
+sudo apt install cmake ninja-build qt6-base-dev qt6-serialport-dev \
+     qt6-svg-dev libqwt-qt6-dev
+
+cmake -S . -B build-ubuntu -G Ninja -DCMAKE_BUILD_TYPE=Release -DBUILD_QWT=false
+cmake --build build-ubuntu --parallel
+cd build-ubuntu && cpack -G DEB
+```
+
+Output: `build-ubuntu/serialplot-<version>-Linux.deb`
+
+Upload to the same release:
+
+```bash
+gh release upload "serialplot-<version>" build-ubuntu/serialplot-<version>-Linux.deb \
+  --repo RolandWa/serialplot
+```
+
+---
+
 ## Bugs fixed in this branch (feature/port-to-qt6)
 
 | Bug | Root cause | Fix |

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -162,28 +162,97 @@ Releases are published at: [github.com/RolandWa/serialplot/releases](https://git
 
 ---
 
-## Ubuntu build (WSL)
+## Ubuntu / Debian build (WSL)
 
-Use WSL with Ubuntu. The original project's packaging scripts work as-is.
+Ubuntu 26.04 (and 22.04+) does not ship `libqwt-qt6-dev`, so Qwt 6.3 is built from source via CMake's `ExternalProject`. Use the provided script — do **not** use the manual cmake commands in the original README.
 
 ```bash
-# Inside WSL Ubuntu
-sudo apt install cmake ninja-build qt6-base-dev qt6-serialport-dev \
-     qt6-svg-dev libqwt-qt6-dev
-
-cmake -S . -B build-ubuntu -G Ninja -DCMAKE_BUILD_TYPE=Release -DBUILD_QWT=false
-cmake --build build-ubuntu --parallel
-cd build-ubuntu && cpack -G DEB
+# Inside WSL Ubuntu — run from the repo root (Windows path via /mnt/c/...)
+./build_ubuntu.sh --package
 ```
 
-Output: `build-ubuntu/serialplot-<version>-Linux.deb`
+The script:
 
-Upload to the same release:
+1. Installs Qt 6 build dependencies via `apt`
+2. Builds Qwt 6.3 first (`cmake --build --target QWT`)
+3. Builds serialplot
+4. Runs `cpack -G DEB` → `serialplot_0.12.1_amd64.deb`
+5. Copies the `.deb` back to the repo root (Windows-accessible)
+
+Build directory is `$HOME/serialplot-build-ubuntu` (WSL native fs, survives WSL restarts).
+
+**Note:** Build dir `/tmp/serialplot-build-ubuntu` is lost on WSL restart — always use `$HOME/`.
+
+Upload to the GitHub release:
 
 ```bash
-gh release upload "serialplot-<version>" build-ubuntu/serialplot-<version>-Linux.deb \
+gh release upload "serialplot-0.12.1" serialplot_0.12.1_amd64.deb \
   --repo RolandWa/serialplot
 ```
+
+Install the package:
+
+```bash
+sudo dpkg -i serialplot_0.12.1_amd64.deb
+sudo apt-get install -f   # fix any missing dependencies
+```
+
+---
+
+## TODO — future work
+
+### #1 — Repeat interval for GUI Commands
+
+**Reference:** [hyOzd/serialplot#1](https://github.com/hyOzd/serialplot/issues/1)
+
+Add a repeat interval control to the end of each command row in the Commands panel so that a command can be sent automatically at a configurable rate.
+
+**Proposed UI** (right side of each `CommandWidget` row):
+
+| Control | Type | Details |
+| --- | --- | --- |
+| Repeat toggle | `QCheckBox` or `QToolButton` | Enables / disables periodic sending |
+| Interval value | `QSpinBox` (sbInterval) | Range 1–99999, default 1000 |
+| Unit selector | `QComboBox` (cbUnit) | Items: `ms`, `s` |
+
+**Implementation sketch:**
+
+```cpp
+// commandwidget.h
+QTimer _repeatTimer;
+int intervalMs() const;      // converts spinbox + unit to milliseconds
+private slots:
+    void onRepeatToggled(bool enabled);
+    void onIntervalChanged();
+```
+
+```cpp
+// commandwidget.cpp
+connect(&_repeatTimer, &QTimer::timeout, this, &CommandWidget::onSendClicked);
+
+void CommandWidget::onRepeatToggled(bool enabled) {
+    if (enabled)
+        _repeatTimer.start(intervalMs());
+    else
+        _repeatTimer.stop();
+}
+
+int CommandWidget::intervalMs() const {
+    int v = ui->sbInterval->value();
+    return ui->cbUnit->currentText() == "s" ? v * 1000 : v;
+}
+```
+
+**Files to change:**
+
+| File | Change |
+| --- | --- |
+| `src/commandwidget.h` | Add `QTimer`, `intervalMs()`, repeat slot declarations |
+| `src/commandwidget.cpp` | Implement repeat logic; stop timer in destructor |
+| `src/commandwidget.ui` | Add Repeat checkbox, sbInterval spinbox, cbUnit combobox |
+| `src/commandpanel.cpp` | Stop all repeat timers when the port / UDP socket is closed |
+
+Settings: save/load repeat state, interval value, and unit alongside existing command settings in `CommandWidget::saveSettings` / `loadSettings`.
 
 ---
 

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -1,0 +1,128 @@
+# serialplot — Development & Testing Guide (Windows)
+
+## Build
+
+Uses MSYS2 ucrt64 + Qt 6.8 + Qwt 6.3. Always build with the provided script.
+
+```powershell
+.\build_windows.ps1 -Install
+```
+
+- `-Install` is mandatory — runs `windeployqt` and copies runtime DLLs into `build-windows\install\bin\`.
+- Without `-Install` the exe fails to start (missing DLLs).
+
+---
+
+## Full test sequence
+
+Run this block from the repo root. It opens a **visible terminal window** for the UDP sender, verifies packets are flowing, then launches serialplot with debug logging.
+
+```powershell
+# 1. Find real Python (skip Microsoft Store stub which exits with code 255)
+$python = @(
+    "$env:LOCALAPPDATA\Programs\Python\Python314\python.exe",
+    "$env:LOCALAPPDATA\Programs\Python\Python313\python.exe",
+    "$env:LOCALAPPDATA\Programs\Python\Python312\python.exe",
+    "$env:LOCALAPPDATA\Programs\Python\Python311\python.exe"
+) | Where-Object { Test-Path $_ } | Select-Object -First 1
+
+$repo = Split-Path -Parent (Resolve-Path ".")
+
+# 2. Open a NEW PowerShell window showing sender output — keep it open
+$script = "$repo\tests\udp_sender.py"
+Start-Process powershell -ArgumentList "-NoExit", "-Command", "& '$python' -u '$script'"
+
+Start-Sleep 2
+
+# 3. Verify sender is actually sending on port 3000
+$r = New-Object System.Net.Sockets.UdpClient(3000)
+$r.Client.ReceiveTimeout = 2000
+try {
+    $ep = [System.Net.IPEndPoint]::new([System.Net.IPAddress]::Any, 0)
+    $d  = $r.Receive([ref]$ep)
+    Write-Host "SENDER OK: $([System.Text.Encoding]::UTF8.GetString($d).Trim())"
+} catch {
+    Write-Host "ERROR: sender not sending — check the Python window for errors"
+    return
+} finally { $r.Close() }
+
+Start-Sleep 1   # release port 3000 before serialplot binds it
+
+# 4. Clear log and start serialplot with debug capture
+$log = "$repo\build-windows\debug.log"
+[System.IO.File]::WriteAllText($log, "")
+Start-Process "$repo\build-windows\install\bin\serialplot.exe" -RedirectStandardError $log
+
+Write-Host "serialplot started."
+Write-Host "  In the app: 1) UDP tab -> Bind   2) Data Format -> ASCII"
+Write-Host "  Close serialplot when done, then read the log (block below)."
+```
+
+After closing serialplot, read the log:
+
+```powershell
+Get-Content "$repo\build-windows\debug.log"
+```
+
+---
+
+## Connect serialplot to UDP data
+
+1. Click the **UDP** tab
+2. Bind Address: `127.0.0.1`, Port: `3000`
+3. Click **Bind** — status shows "Bound to 127.0.0.1:3000"
+4. Click the **Data Format** tab → select **ASCII**
+5. Set **Number of channels** to **Auto** (spinbox value 0)
+6. Plot shows live data on 3 channels — legend shows **temp**, **humidity**, **pressure**
+
+---
+
+## How Arduino-style labels work
+
+The UDP sender sends lines like `temp:22.5,humidity:58.1,pressure:1015.0`.
+
+serialplot automatically detects `key:value` pairs and uses the keys as channel names:
+
+- The ASCII reader splits on `,` (auto-detected delimiter)
+- `key:value` fields: the key becomes the channel name, the value is plotted
+- Channel count is auto-detected from the first parsed line
+- Names appear in the plot legend and the Names tab in Plot Control
+
+**Settings required for this to work:**
+
+- Delimiter: **Auto** (or **Comma**)
+- Number of channels: **Auto** (spinbox = 0)
+
+---
+
+## Key log messages
+
+| Message | Meaning |
+| --- | --- |
+| `[UDP] bound to "127.0.0.1" port 3000` | Socket bound OK |
+| `[UDP] bind failed: ...` | Port in use or firewall blocking |
+| `[UDP] rx: "temp:..."` | Datagram received — sender is working |
+| `[Debug] SerialPlot 0.12.1` | App started, version confirmed |
+
+**No `[UDP] rx:` after clicking Bind?**
+
+- Sender window closed — rerun the start block, check `SENDER OK` line
+- Try Bind Address `0.0.0.0` instead of `127.0.0.1`
+
+**`[UDP] rx:` appears but plot is empty?**
+
+- ASCII not selected — Data Format tab → ASCII radio button
+
+**Values plot but channel names show "Channel 1, 2, 3"?**
+
+- Number of channels is not set to Auto — set spinbox to 0
+
+---
+
+## Bugs fixed in this branch (feature/port-to-qt6)
+
+| Bug | Root cause | Fix |
+| --- | --- | --- |
+| UDP data never parsed by ASCII reader | Qt 6 `QIODevice::canReadLine()` only checks internal buffer, ignoring `UdpLineDevice::_buf` | Override `canReadLine()` in `UdpLineDevice` to also check `_buf.contains('\n')` |
+| Arduino-style channel names not applied | `DataFormatPanel::selectReader()` called twice on startup via `loadSettings` (explicit call + radio button signal), second call ran `disconnect(&asciiReader, 0, this, 0)` destroying the `labelsReceived` connection | Guard `selectReader()` with `if (reader == currentReader) return` |
+| Channel names emitted before channels existed | `labelsReceived` emitted before `updateNumChannels()` in auto-channel mode, so `ChannelInfoModel::setNames` found `_numOfChannels = 0` | Move `emit labelsReceived` to after `updateNumChannels()` inside `if (samples != nullptr)` |

--- a/build_ubuntu.sh
+++ b/build_ubuntu.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+# build_ubuntu.sh — Build serialplot .deb package on Ubuntu (native or WSL)
+# Run from the repo root:  ./build_ubuntu.sh
+# Optional: pass --package to also run cpack and produce a .deb
+
+set -e
+
+PACKAGE=false
+BUILD_DIR=""
+
+for arg in "$@"; do
+    case $arg in
+        --package) PACKAGE=true ;;
+        --build-dir=*) BUILD_DIR="${arg#*=}" ;;
+    esac
+done
+
+REPO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# Default build dir: use WSL native fs if running under WSL (faster than /mnt/...)
+if [ -z "$BUILD_DIR" ]; then
+    if grep -qi microsoft /proc/version 2>/dev/null; then
+        BUILD_DIR="$HOME/serialplot-build-ubuntu"
+    else
+        BUILD_DIR="$REPO_DIR/build-ubuntu"
+    fi
+fi
+
+echo "=== Installing build dependencies ==="
+sudo apt-get update -qq
+sudo apt-get install -y --no-install-recommends \
+    cmake \
+    ninja-build \
+    make \
+    qt6-base-dev \
+    qt6-serialport-dev \
+    qt6-svg-dev \
+    libqt6opengl6-dev \
+    qmake6 \
+    dpkg-dev \
+    libgl-dev
+
+echo ""
+echo "=== Configuring (build dir: $BUILD_DIR) ==="
+cmake -S "$REPO_DIR" \
+      -B "$BUILD_DIR" \
+      -G Ninja \
+      -DCMAKE_BUILD_TYPE=Release \
+      -DBUILD_QWT=true
+
+echo ""
+echo "=== Building Qwt (ExternalProject) ==="
+cmake --build "$BUILD_DIR" --target QWT
+
+echo ""
+echo "=== Building serialplot ==="
+cmake --build "$BUILD_DIR" --parallel
+
+echo ""
+echo "=== Build complete ==="
+echo "Executable: $BUILD_DIR/serialplot"
+
+if [ "$PACKAGE" = true ]; then
+    echo ""
+    echo "=== Building .deb package (CPack) ==="
+    cd "$BUILD_DIR"
+    cpack -G DEB
+    DEB=$(ls serialplot*.deb 2>/dev/null | head -1)
+    if [ -n "$DEB" ]; then
+        # Copy back to repo root so it's accessible from Windows
+        cp "$DEB" "$REPO_DIR/"
+        echo ""
+        echo "Package: $REPO_DIR/$DEB"
+    fi
+fi

--- a/build_windows.ps1
+++ b/build_windows.ps1
@@ -1,0 +1,165 @@
+# build_windows.ps1 — Build serialplot on Windows using MSYS2 UCRT64
+# Run from the repo root:  .\build_windows.ps1
+# Optional: pass -Install to also run cmake --install
+
+param(
+    [switch]$Install,
+    [string]$BuildDir = "build-windows"
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+
+$MSYS2  = "C:\msys64"
+$PACMAN = "$MSYS2\usr\bin\pacman.exe"
+$BASH   = "$MSYS2\usr\bin\bash.exe"
+$UCRT64 = "$MSYS2\ucrt64"
+
+if (-not (Test-Path $MSYS2)) {
+    Write-Error "MSYS2 not found at $MSYS2. Install from https://www.msys2.org/"
+}
+
+# Convert a Windows path to an MSYS2 unix path  (C:\foo\bar -> /c/foo/bar)
+function ToUnix([string]$p) {
+    $p = $p -replace '\\', '/'
+    if ($p -match '^([A-Za-z]):(.*)') {
+        $p = '/' + $Matches[1].ToLower() + $Matches[2]
+    }
+    return $p
+}
+
+# ---------------------------------------------------------------------------
+# 1. Install required packages into the UCRT64 environment
+# ---------------------------------------------------------------------------
+Write-Host "`n=== Installing build dependencies via pacman ===" -ForegroundColor Cyan
+
+$packages = @(
+    "mingw-w64-ucrt-x86_64-gcc",
+    "mingw-w64-ucrt-x86_64-cmake",
+    "mingw-w64-ucrt-x86_64-ninja",
+    "mingw-w64-ucrt-x86_64-qt6-base",
+    "mingw-w64-ucrt-x86_64-qt6-serialport",
+    "mingw-w64-ucrt-x86_64-qt6-svg",
+    "mingw-w64-ucrt-x86_64-qt6-tools",
+    "mingw-w64-ucrt-x86_64-make",
+    "mingw-w64-ucrt-x86_64-qwt-qt6"
+)
+
+& $PACMAN -S --needed --noconfirm @packages
+if ($LASTEXITCODE -ne 0) { Write-Error "pacman failed" }
+
+# ---------------------------------------------------------------------------
+# 2. Configure + Build via a temp bash script (avoids PowerShell $ expansion)
+# ---------------------------------------------------------------------------
+$repoDir  = $PSScriptRoot
+$buildDir = Join-Path $repoDir $BuildDir
+
+$repoUnix  = ToUnix $repoDir
+$buildUnix = ToUnix $buildDir
+
+$tmpScript = "$env:TEMP\serialplot_build.sh"
+
+$bashScript = @'
+#!/usr/bin/env bash
+set -e
+export PATH="/ucrt64/bin:$PATH"
+
+REPO_DIR="__REPO__"
+BUILD_DIR="__BUILD__"
+
+echo "=== CMake configure ==="
+cmake -S "$REPO_DIR" \
+      -B "$BUILD_DIR" \
+      -G Ninja \
+      -DCMAKE_BUILD_TYPE=Release \
+      -DBUILD_QWT=false \
+      -DCMAKE_MODULE_PATH="$REPO_DIR/cmake/windows" \
+      -DQWT_INCLUDE_DIR="C:/msys64/ucrt64/include/qwt-qt6" \
+      -DQWT_LIBRARY="C:/msys64/ucrt64/bin/qwt-qt6.dll"
+
+echo "=== Building ==="
+cmake --build "$BUILD_DIR" --parallel
+'@
+
+$bashScript = $bashScript -replace '__REPO__', $repoUnix -replace '__BUILD__', $buildUnix
+
+[System.IO.File]::WriteAllText($tmpScript, $bashScript, [System.Text.Encoding]::UTF8)
+
+Write-Host "`n=== Configuring and building (build dir: $buildDir) ===" -ForegroundColor Cyan
+& $BASH --login $tmpScript
+if ($LASTEXITCODE -ne 0) { Write-Error "Build failed" }
+
+# ---------------------------------------------------------------------------
+# 3. Optional install (collects Qt DLLs via windeployqt)
+# ---------------------------------------------------------------------------
+if ($Install) {
+    $installDir  = Join-Path $buildDir "install"
+    $installUnix = ToUnix $installDir
+
+    $tmpInstall = "$env:TEMP\serialplot_install.sh"
+
+    $installScript = @'
+#!/usr/bin/env bash
+set -e
+export PATH="/ucrt64/bin:$PATH"
+cmake --install "__BUILD__" --prefix "__INSTALL__"
+'@
+    $installScript = $installScript -replace '__BUILD__', $buildUnix -replace '__INSTALL__', $installUnix
+    [System.IO.File]::WriteAllText($tmpInstall, $installScript, [System.Text.Encoding]::UTF8)
+
+    Write-Host "`n=== Installing to $installDir ===" -ForegroundColor Cyan
+    & $BASH --login $tmpInstall
+    if ($LASTEXITCODE -ne 0) { Write-Error "Install failed" }
+
+    # Copy Qwt and MinGW/MSYS2 runtime DLLs not handled by windeployqt
+    Write-Host "`n=== Copying runtime DLLs ===" -ForegroundColor Cyan
+    $installBin = Join-Path $installDir "bin"
+    $objdump    = "$UCRT64\bin\objdump.exe"
+    $systemDlls = '^(KERNEL32|USER32|GDI32|SHELL32|ADVAPI32|ole32|OLEAUT32|NTDLL|WS2_32|api-ms-win|UCRTBASE|msvc|D3D|OPENGL|dwmapi|UxTheme|DWRITE|WindowsCodecs|SETUPAPI|CFGMGR32|bcrypt|IMM32|SHLWAPI|WTSAPI32|RPCRT4|NETAPI32|MPR|SHCORE|DNSAPI|dxgi|WINHTTP|VERSION|AUTHZ|comdlg32|CRYPT32|IPHLPAPI|USERENV|WINMM|Secur32|ncrypt)'
+
+    $present = (Get-ChildItem $installBin -Filter "*.dll" -Recurse | Select-Object -ExpandProperty Name)
+
+    $toCopy = [System.Collections.Generic.HashSet[string]]::new([System.StringComparer]::OrdinalIgnoreCase)
+    Get-ChildItem $installBin -Filter "*.dll" -Recurse | ForEach-Object {
+        & $objdump -p $_.FullName 2>$null |
+            Select-String "DLL Name" |
+            ForEach-Object {
+                $dll = ($_ -replace '.*DLL Name:\s*','').Trim()
+                if ($dll -notmatch $systemDlls -and $present -notcontains $dll) {
+                    $null = $toCopy.Add($dll)
+                }
+            }
+    }
+    # Always ensure Qwt and its Qt dependencies are included
+    # (qwt-qt6.dll isn't in install yet when we scan, so add its deps explicitly)
+    $null = $toCopy.Add("qwt-qt6.dll")
+    $null = $toCopy.Add("Qt6OpenGL.dll")
+    $null = $toCopy.Add("Qt6OpenGLWidgets.dll")
+    $null = $toCopy.Add("libicudt76.dll")
+    $null = $toCopy.Add("libbrotlicommon.dll")
+    $null = $toCopy.Add("libbrotlidec.dll")
+    $null = $toCopy.Add("libbrotlienc.dll")
+    $null = $toCopy.Add("libharfbuzz-0.dll")
+    $null = $toCopy.Add("libharfbuzz-gobject-0.dll")
+    $null = $toCopy.Add("libharfbuzz-subset-0.dll")
+    $null = $toCopy.Add("libbz2-1.dll")
+    $null = $toCopy.Add("libglib-2.0-0.dll")
+    $null = $toCopy.Add("libgraphite2.dll")
+    $null = $toCopy.Add("libintl-8.dll")
+    $null = $toCopy.Add("libpcre2-8-0.dll")
+    $null = $toCopy.Add("libiconv-2.dll")
+
+    foreach ($dll in $toCopy) {
+        $src = Join-Path "$UCRT64\bin" $dll
+        if (Test-Path $src) {
+            Copy-Item $src $installBin -Force
+            Write-Host "  Copied: $dll" -ForegroundColor Green
+        }
+    }
+
+    Write-Host "`nInstalled to: $installDir" -ForegroundColor Green
+    Write-Host "Run:  $installDir\bin\serialplot.exe"
+}
+
+Write-Host "`n=== Build complete ===" -ForegroundColor Green
+Write-Host "Executable: $buildDir\serialplot.exe"

--- a/build_windows.ps1
+++ b/build_windows.ps1
@@ -4,6 +4,7 @@
 
 param(
     [switch]$Install,
+    [switch]$Package,
     [string]$BuildDir = "build-windows"
 )
 
@@ -44,6 +45,10 @@ $packages = @(
     "mingw-w64-ucrt-x86_64-make",
     "mingw-w64-ucrt-x86_64-qwt-qt6"
 )
+
+if ($Package) {
+    $packages += "mingw-w64-ucrt-x86_64-nsis"
+}
 
 & $PACMAN -S --needed --noconfirm @packages
 if ($LASTEXITCODE -ne 0) { Write-Error "pacman failed" }
@@ -163,3 +168,29 @@ cmake --install "__BUILD__" --prefix "__INSTALL__"
 
 Write-Host "`n=== Build complete ===" -ForegroundColor Green
 Write-Host "Executable: $buildDir\serialplot.exe"
+
+# ---------------------------------------------------------------------------
+# 4. Optional package (NSIS Windows installer via CPack)
+# ---------------------------------------------------------------------------
+if ($Package) {
+    Write-Host "`n=== Building Windows installer (CPack/NSIS) ===" -ForegroundColor Cyan
+
+    $tmpPack = "$env:TEMP\serialplot_pack.sh"
+    $packScript = @'
+#!/usr/bin/env bash
+set -e
+export PATH="/ucrt64/bin:$PATH"
+cd "__BUILD__"
+cpack -G NSIS
+'@
+    $packScript = $packScript -replace '__BUILD__', $buildUnix
+    [System.IO.File]::WriteAllText($tmpPack, $packScript, [System.Text.Encoding]::UTF8)
+
+    & $BASH --login $tmpPack
+    if ($LASTEXITCODE -ne 0) { Write-Error "CPack failed" }
+
+    $installer = Get-ChildItem $buildDir -Filter "serialplot-*.exe" | Sort-Object LastWriteTime -Descending | Select-Object -First 1
+    if ($installer) {
+        Write-Host "`nInstaller: $($installer.FullName)" -ForegroundColor Green
+    }
+}

--- a/cmake/windows/FindQwt.cmake
+++ b/cmake/windows/FindQwt.cmake
@@ -1,0 +1,15 @@
+# Windows override for FindQwt.cmake
+# Used when building with the MSYS2 ucrt64 pre-built Qwt package.
+# Paths are injected by build_windows.ps1 via -DQWT_INCLUDE_DIR and -DQWT_LIBRARY.
+# The original FindQwt.cmake uses GET_PREREQUISITES which fails on Windows DLL
+# import libraries, so this override is searched first via CMAKE_MODULE_PATH.
+
+if (NOT QWT_INCLUDE_DIR OR NOT QWT_LIBRARY)
+  message(FATAL_ERROR "QWT_INCLUDE_DIR and QWT_LIBRARY must be set for Windows builds.")
+endif()
+
+set(QWT_INCLUDE_DIRS ${QWT_INCLUDE_DIR})
+set(QWT_LIBRARIES    ${QWT_LIBRARY})
+set(QWT_FOUND        true)
+
+message(STATUS "Found Qwt (Windows override): ${QWT_LIBRARY}")

--- a/src/about_dialog.ui
+++ b/src/about_dialog.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>519</width>
-    <height>334</height>
+    <height>340</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -23,7 +23,20 @@
       </sizepolicy>
      </property>
      <property name="text">
-      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p align=&quot;center&quot;&gt;&lt;span style=&quot; font-size:14pt;&quot;&gt;SerialPlot&lt;/span&gt;&lt;/p&gt;&lt;p align=&quot;center&quot;&gt;$VERSION_STRING$&lt;/p&gt;&lt;p align=&quot;center&quot;&gt;Developed by Hasan Yavuz Özderya&lt;/p&gt;&lt;p align=&quot;center&quot;&gt;Using Qt (&lt;a href=&quot;https://www.qt.io/&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0000ff;&quot;&gt;https://www.qt.io/&lt;/span&gt;&lt;/a&gt;) and Qwt (&lt;a href=&quot;http://qwt.sf.net&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0000ff;&quot;&gt;http://qwt.sf.net&lt;/span&gt;&lt;/a&gt;)&lt;/p&gt;&lt;p align=&quot;center&quot;&gt;&lt;br/&gt;&lt;/p&gt;&lt;p align=&quot;center&quot;&gt;This software is GPL licensed. You can obtain source code from &lt;a href=&quot;https://hg.sr.ht/~hyozd/serialplot/&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0000ff;&quot;&gt;https://hg.sr.ht/~hyozd/serialplot/&lt;/span&gt;&lt;/a&gt;.&lt;/p&gt;&lt;p align=&quot;center&quot;&gt;&lt;br/&gt;&lt;/p&gt;&lt;p align=&quot;right&quot;&gt;&lt;span style=&quot; font-size:8pt;&quot;&gt;RevID: $VERSION_REVISION$&lt;br/&gt;&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;
+&lt;p align=&quot;center&quot;&gt;&lt;span style=&quot; font-size:14pt;&quot;&gt;SerialPlot&lt;/span&gt;&lt;/p&gt;
+&lt;p align=&quot;center&quot;&gt;$VERSION_STRING$&lt;/p&gt;
+&lt;p align=&quot;center&quot;&gt;
+  Author: Hasan Yavuz Özderya&lt;br/&gt;
+  &lt;a href=&quot;https://github.com/hyOzd/serialplot&quot;&gt;https://github.com/hyOzd/serialplot&lt;/a&gt;
+&lt;/p&gt;
+&lt;p align=&quot;center&quot;&gt;
+  Fork by Roland W.&lt;br/&gt;
+  &lt;a href=&quot;https://github.com/RolandWa/serialplot&quot;&gt;https://github.com/RolandWa/serialplot&lt;/a&gt;
+&lt;/p&gt;
+&lt;p align=&quot;center&quot;&gt;This software is GPL licensed.&lt;/p&gt;
+&lt;p align=&quot;right&quot;&gt;&lt;span style=&quot; font-size:8pt;&quot;&gt;RevID: $VERSION_REVISION$&lt;/span&gt;&lt;/p&gt;
+&lt;/body&gt;&lt;/html&gt;</string>
      </property>
      <property name="wordWrap">
       <bool>true</bool>

--- a/src/abstractreader.cpp
+++ b/src/abstractreader.cpp
@@ -17,6 +17,7 @@
   along with serialplot.  If not, see <http://www.gnu.org/licenses/>.
 */
 
+#include <QtDebug>
 #include "abstractreader.h"
 
 AbstractReader::AbstractReader(QIODevice* device, QObject* parent) :
@@ -33,6 +34,7 @@ void AbstractReader::pause(bool enabled)
 
 void AbstractReader::enable(bool enabled)
 {
+    _enabled = enabled;
     if (enabled)
     {
         QObject::connect(_device, &QIODevice::readyRead,
@@ -42,6 +44,17 @@ void AbstractReader::enable(bool enabled)
     {
         QObject::disconnect(_device, 0, this, 0);
         disconnectSinks();
+    }
+}
+
+void AbstractReader::setDevice(QIODevice* device)
+{
+    QObject::disconnect(_device, &QIODevice::readyRead, this, &AbstractReader::onDataReady);
+    _device = device;
+    if (_enabled)
+    {
+        QObject::connect(_device, &QIODevice::readyRead,
+                         this, &AbstractReader::onDataReady);
     }
 }
 

--- a/src/abstractreader.h
+++ b/src/abstractreader.h
@@ -46,6 +46,10 @@ public:
     /// 'disabled'.
     virtual void enable(bool enabled = true);
 
+    /// Swap the underlying I/O device (e.g. switch from serial to UDP).
+    /// The readyRead signal is rewired automatically.
+    void setDevice(QIODevice* device);
+
     /// None of the current readers support X channel at the moment
     bool hasX() const final { return false; };
 
@@ -72,6 +76,7 @@ protected:
     /// Reader should check this variable to determine if reading is
     /// paused in `readData()`
     bool paused;
+    bool _enabled = false;
 
     /**
      * Called when `readyRead` is signaled by the device. This is

--- a/src/asciireader.cpp
+++ b/src/asciireader.cpp
@@ -136,6 +136,9 @@ unsigned AsciiReader::readData()
                 break;
         }
 
+        // detect Arduino-style labels to apply after channel count is finalized
+        QStringList labels = extractLabels(line);
+
         const SamplePack* samples = parseLine(line);
         if (samples != nullptr) {
             // update number of channels if in auto mode
@@ -151,6 +154,12 @@ unsigned AsciiReader::readData()
 
             Q_ASSERT(samples->numChannels() == _numChannels);
 
+            // emit labels after channels exist so setNames finds the right count
+            if (!labels.isEmpty() && labels != _lastLabels) {
+                _lastLabels = labels;
+                emit labelsReceived(labels);
+            }
+
             // commit data
             feedOut(*samples);
             delete samples;
@@ -160,9 +169,25 @@ unsigned AsciiReader::readData()
     return numBytesRead;
 }
 
+static QString detectDelimiter(const QString& line)
+{
+    // Try each candidate in priority order; pick the first one that actually
+    // splits the line into more than one field.
+    // Colon comes last because it appears inside Arduino "label:value" pairs
+    // and must not be mistaken for the field separator.
+    static const QStringList candidates = {"\t", ";", ",", " ", ":"};
+    for (const QString& sep : candidates)
+    {
+        if (line.split(sep, Qt::SkipEmptyParts).size() > 1)
+            return sep;
+    }
+    return ",";
+}
+
 SamplePack* AsciiReader::parseLine(const QString& line) const
 {
-    auto separatedValues = line.split(delimiter, Qt::SkipEmptyParts);
+    QString sep = delimiter.isEmpty() ? detectDelimiter(line) : delimiter;
+    auto separatedValues = line.split(sep, Qt::SkipEmptyParts);
     unsigned numComingChannels = separatedValues.length();
 
     // check number of channels (skipped if auto num channels is enabled)
@@ -203,6 +228,28 @@ SamplePack* AsciiReader::parseLine(const QString& line) const
     }
 
     return samples;
+}
+
+QStringList AsciiReader::extractLabels(const QString& line) const
+{
+    QString sep = delimiter.isEmpty() ? detectDelimiter(line) : delimiter;
+    auto fields = line.split(sep, Qt::SkipEmptyParts);
+    QStringList labels;
+    bool hasAnyLabel = false;
+    for (const QString& field : fields)
+    {
+        int colonPos = field.indexOf(':');
+        if (colonPos > 0)
+        {
+            labels.append(field.left(colonPos).trimmed());
+            hasAnyLabel = true;
+        }
+        else
+        {
+            labels.append(QString());
+        }
+    }
+    return hasAnyLabel ? labels : QStringList();
 }
 
 void AsciiReader::saveSettings(QSettings* settings)

--- a/src/asciireader.h
+++ b/src/asciireader.h
@@ -41,6 +41,10 @@ public:
     /// Loads settings from a `QSettings`.
     void loadSettings(QSettings* settings);
 
+signals:
+    /// Emitted when Arduino-style labels are detected in incoming data
+    void labelsReceived(QStringList labels);
+
 private:
     AsciiReaderSettings _settingsWidget;
     unsigned _numChannels;
@@ -52,10 +56,9 @@ private:
     QString filterPrefix; ///< selected ASCII mode filter prefix
 
     bool firstReadAfterEnable = false;
+    QStringList _lastLabels; ///< last emitted Arduino-style channel labels
 
     unsigned readData() override;
-
-private slots:
 
     /**
      * Parses given line and returns sample pack.
@@ -63,6 +66,13 @@ private slots:
      * Returns `nullptr` in case of error.
      */
     SamplePack* parseLine(const QString& line) const;
+
+    /**
+     * Extracts Arduino-style labels from a line (e.g. "temp:23.5,hum:61.2").
+     *
+     * Returns an empty list if no labels are found.
+     */
+    QStringList extractLabels(const QString& line) const;
 };
 
 #endif // ASCIIREADER_H

--- a/src/asciireadersettings.cpp
+++ b/src/asciireadersettings.cpp
@@ -37,9 +37,12 @@ AsciiReaderSettings::AsciiReaderSettings(QWidget *parent) :
 
     ui->spNumOfChannels->setMaximum(MAX_NUM_CHANNELS);
 
+    delimiterButtons.addButton(ui->rbAuto);
     delimiterButtons.addButton(ui->rbComma);
     delimiterButtons.addButton(ui->rbSpace);
     delimiterButtons.addButton(ui->rbTab);
+    delimiterButtons.addButton(ui->rbColon);
+    delimiterButtons.addButton(ui->rbSemicolon);
     delimiterButtons.addButton(ui->rbOtherDelimiter);
 
     filterButtons.addButton(ui->rbFilterDisabled, (int) FilterMode::disabled);
@@ -47,11 +50,17 @@ AsciiReaderSettings::AsciiReaderSettings(QWidget *parent) :
     filterButtons.addButton(ui->rbFilterExclude, (int) FilterMode::exclude);
 
     // delimiter buttons signals
+    connect(ui->rbAuto, &QAbstractButton::toggled,
+            this, &AsciiReaderSettings::delimiterToggled);
     connect(ui->rbComma, &QAbstractButton::toggled,
             this, &AsciiReaderSettings::delimiterToggled);
     connect(ui->rbSpace, &QAbstractButton::toggled,
             this, &AsciiReaderSettings::delimiterToggled);
     connect(ui->rbTab, &QAbstractButton::toggled,
+            this, &AsciiReaderSettings::delimiterToggled);
+    connect(ui->rbColon, &QAbstractButton::toggled,
+            this, &AsciiReaderSettings::delimiterToggled);
+    connect(ui->rbSemicolon, &QAbstractButton::toggled,
             this, &AsciiReaderSettings::delimiterToggled);
     connect(ui->rbOtherDelimiter, &QAbstractButton::toggled,
             this, &AsciiReaderSettings::delimiterToggled);
@@ -104,7 +113,11 @@ AsciiReaderSettings::FilterMode AsciiReaderSettings::filterMode() const
 
 QString AsciiReaderSettings::delimiter() const
 {
-    if (ui->rbComma->isChecked())
+    if (ui->rbAuto->isChecked())
+    {
+        return QString(); // empty string = auto-detect
+    }
+    else if (ui->rbComma->isChecked())
     {
         return QChar(',');
     }
@@ -115,6 +128,14 @@ QString AsciiReaderSettings::delimiter() const
     else if (ui->rbTab->isChecked())
     {
         return QChar('\t');
+    }
+    else if (ui->rbColon->isChecked())
+    {
+        return QChar(':');
+    }
+    else if (ui->rbSemicolon->isChecked())
+    {
+        return QChar(';');
     }
     else                        // rbOther
     {
@@ -131,11 +152,8 @@ void AsciiReaderSettings::delimiterToggled(bool checked)
 {
     if (!checked) return;
 
-    auto d = delimiter();
-    if (!d.isNull())
-    {
-        emit delimiterChanged(d);
-    }
+    // emit empty string for auto-detect mode so the reader knows to switch
+    emit delimiterChanged(delimiter());
 }
 
 void AsciiReaderSettings::customDelimiterChanged(const QString text)
@@ -157,7 +175,11 @@ void AsciiReaderSettings::saveSettings(QSettings* settings)
 
     // save delimiter
     QString delimiterS;
-    if (ui->rbOtherDelimiter->isChecked())
+    if (ui->rbAuto->isChecked())
+    {
+        delimiterS = "auto";
+    }
+    else if (ui->rbOtherDelimiter->isChecked())
     {
         delimiterS = "other";
     }
@@ -165,6 +187,14 @@ void AsciiReaderSettings::saveSettings(QSettings* settings)
     {
         // Note: \t is not correctly loaded
         delimiterS = "TAB";
+    }
+    else if (ui->rbColon->isChecked())
+    {
+        delimiterS = "COLON";
+    }
+    else if (ui->rbSemicolon->isChecked())
+    {
+        delimiterS = "SEMICOLON";
     }
     else
     {
@@ -221,7 +251,11 @@ void AsciiReaderSettings::loadSettings(QSettings* settings)
     auto delimiterS = settings->value(SG_ASCII_Delimiter, delimiter()).toString();
     auto customDelimiter = settings->value(SG_ASCII_CustomDelimiter, delimiter()).toString();
     if (!customDelimiter.isEmpty()) ui->leDelimiter->setText(customDelimiter);
-    if (delimiterS == ",")
+    if (delimiterS == "auto")
+    {
+        ui->rbAuto->setChecked(true);
+    }
+    else if (delimiterS == ",")
     {
         ui->rbComma->setChecked(true);
     }
@@ -232,6 +266,14 @@ void AsciiReaderSettings::loadSettings(QSettings* settings)
     else if (delimiterS == "TAB")
     {
         ui->rbTab->setChecked(true);
+    }
+    else if (delimiterS == "COLON")
+    {
+        ui->rbColon->setChecked(true);
+    }
+    else if (delimiterS == "SEMICOLON")
+    {
+        ui->rbSemicolon->setChecked(true);
     }
     else
     {

--- a/src/asciireadersettings.ui
+++ b/src/asciireadersettings.ui
@@ -71,12 +71,22 @@
    <item row="2" column="1">
     <layout class="QHBoxLayout" name="horizontalLayout">
      <item>
-      <widget class="QRadioButton" name="rbComma">
+      <widget class="QRadioButton" name="rbAuto">
        <property name="text">
-        <string>comma</string>
+        <string>auto</string>
        </property>
        <property name="checked">
         <bool>true</bool>
+       </property>
+       <property name="toolTip">
+        <string>Automatically detect the delimiter from incoming data</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QRadioButton" name="rbComma">
+       <property name="text">
+        <string>comma</string>
        </property>
       </widget>
      </item>
@@ -91,6 +101,20 @@
       <widget class="QRadioButton" name="rbTab">
        <property name="text">
         <string>tab</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QRadioButton" name="rbColon">
+       <property name="text">
+        <string>colon (:)</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QRadioButton" name="rbSemicolon">
+       <property name="text">
+        <string>semicolon (;)</string>
        </property>
       </widget>
      </item>

--- a/src/channelinfomodel.cpp
+++ b/src/channelinfomodel.cpp
@@ -19,6 +19,7 @@
 
 #include "channelinfomodel.h"
 #include "setting_defines.h"
+#include <QtDebug>
 
 #define NUMOF_COLORS  (32)
 
@@ -428,6 +429,17 @@ void ChannelInfoModel::resetNames()
         infos[ci].name = ChannelInfo(ci).name;
     }
     endResetModel();
+}
+
+void ChannelInfoModel::setNames(QStringList names)
+{
+    for (int i = 0; i < names.size() && i < (int) _numOfChannels; i++)
+    {
+        if (!names[i].isEmpty())
+        {
+            setData(index(i, COLUMN_NAME), names[i], Qt::EditRole);
+        }
+    }
 }
 
 void ChannelInfoModel::resetColors()

--- a/src/channelinfomodel.h
+++ b/src/channelinfomodel.h
@@ -74,6 +74,8 @@ public slots:
     void resetInfos();
     /// reset all channel names
     void resetNames();
+    /// set channel names from a list (Arduino label import)
+    void setNames(QStringList names);
     /// reset all channel colors
     void resetColors();
     /// reset all channel gain values and disables gains

--- a/src/dataformatpanel.cpp
+++ b/src/dataformatpanel.cpp
@@ -65,6 +65,9 @@ DataFormatPanel::DataFormatPanel(QSerialPort* port, QWidget *parent) :
             {
                 if (checked) selectReader(&framedReader);
             });
+
+    connect(&asciiReader, &AsciiReader::labelsReceived,
+            this, &DataFormatPanel::onAsciiLabelsReceived);
 }
 
 DataFormatPanel::~DataFormatPanel()
@@ -116,6 +119,8 @@ bool DataFormatPanel::isDemoEnabled() const
 
 void DataFormatPanel::selectReader(AbstractReader* reader)
 {
+    if (reader == currentReader) return;
+
     currentReader->enable(false);
     reader->enable();
 
@@ -132,6 +137,18 @@ void DataFormatPanel::selectReader(AbstractReader* reader)
 
     currentReader = reader;
     emit sourceChanged(currentReader);
+}
+
+void DataFormatPanel::onAsciiLabelsReceived(QStringList labels)
+{
+    emit channelLabelsReceived(labels);
+}
+
+void DataFormatPanel::setDevice(QIODevice* device)
+{
+    bsReader.setDevice(device);
+    asciiReader.setDevice(device);
+    framedReader.setDevice(device);
 }
 
 uint64_t DataFormatPanel::bytesRead()

--- a/src/dataformatpanel.h
+++ b/src/dataformatpanel.h
@@ -24,6 +24,7 @@
 #include <QWidget>
 #include <QButtonGroup>
 #include <QSerialPort>
+#include <QIODevice>
 #include <QList>
 #include <QSettings>
 #include <QtGlobal>
@@ -45,6 +46,8 @@ class DataFormatPanel : public QWidget
 
 public:
     explicit DataFormatPanel(QSerialPort* port, QWidget* parent = 0);
+    /// Switch all readers to a different I/O device (e.g. UDP socket).
+    void setDevice(QIODevice* device);
     ~DataFormatPanel();
 
     /// Returns currently selected number of channels
@@ -65,6 +68,8 @@ public slots:
 signals:
     /// Active (selected) reader has changed.
     void sourceChanged(Source* source);
+    /// Emitted when AsciiReader detects Arduino-style channel labels.
+    void channelLabelsReceived(QStringList labels);
 
 private:
     Ui::DataFormatPanel *ui;
@@ -87,6 +92,9 @@ private:
     AbstractReader* readerBeforeDemo;
 
     bool isDemoEnabled() const;
+
+private slots:
+    void onAsciiLabelsReceived(QStringList labels);
 };
 
 #endif // DATAFORMATPANEL_H

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -80,11 +80,12 @@ MainWindow::MainWindow(QWidget *parent) :
     plotMan = new PlotManager(ui->plotArea, &plotMenu, &stream);
 
     ui->tabWidget->insertTab(0, &portControl, "Port");
-    ui->tabWidget->insertTab(1, &dataFormatPanel, "Data Format");
-    ui->tabWidget->insertTab(2, &plotControlPanel, "Plot");
-    ui->tabWidget->insertTab(3, &commandPanel, "Commands");
-    ui->tabWidget->insertTab(4, &recordPanel, "Record");
-    ui->tabWidget->insertTab(5, &textView, "Text View");
+    ui->tabWidget->insertTab(1, &udpControl, "UDP");
+    ui->tabWidget->insertTab(2, &dataFormatPanel, "Data Format");
+    ui->tabWidget->insertTab(3, &plotControlPanel, "Plot");
+    ui->tabWidget->insertTab(4, &commandPanel, "Commands");
+    ui->tabWidget->insertTab(5, &recordPanel, "Record");
+    ui->tabWidget->insertTab(6, &textView, "Text View");
     ui->tabWidget->setCurrentIndex(0);
     auto tbPortControl = portControl.toolBar();
     addToolBar(tbPortControl);
@@ -166,6 +167,10 @@ MainWindow::MainWindow(QWidget *parent) :
     // port control signals
     QObject::connect(&portControl, &PortControl::portToggled,
                      this, &MainWindow::onPortToggled);
+
+    // UDP control signals
+    QObject::connect(&udpControl, &UdpControl::socketToggled,
+                     this, &MainWindow::onUdpToggled);
 
     // plot control signals
     connect(&plotControlPanel, &PlotControlPanel::numOfSamplesChanged,
@@ -266,6 +271,10 @@ MainWindow::MainWindow(QWidget *parent) :
     connect(&dataFormatPanel, &DataFormatPanel::sourceChanged,
             this, &MainWindow::onSourceChanged);
     onSourceChanged(dataFormatPanel.activeSource());
+
+    // Arduino label auto-detection: apply detected channel names to the model
+    connect(&dataFormatPanel, &DataFormatPanel::channelLabelsReceived,
+            stream.infoModel(), &ChannelInfoModel::setNames);
 
     // load default settings
     QSettings settings(PROGRAM_NAME, PROGRAM_NAME);
@@ -375,9 +384,34 @@ void MainWindow::onPortToggled(bool open)
     if (open && isDemoRunning()) enableDemo(false);
     ui->actionDemoMode->setEnabled(!open);
 
-    if (!open)
+    if (open)
+    {
+        // serial port takes priority — switch readers back to serial
+        dataFormatPanel.setDevice(&serialPort);
+    }
+    else
     {
         spsLabel.setText("0sps");
+        // if UDP is still bound, hand readers back to it
+        if (udpControl.isBound())
+            dataFormatPanel.setDevice(udpControl.device());
+    }
+}
+
+void MainWindow::onUdpToggled(bool bound)
+{
+    if (bound)
+    {
+        // close serial port if open, then switch readers to UDP
+        if (serialPort.isOpen()) serialPort.close();
+        dataFormatPanel.setDevice(udpControl.device());
+        ui->actionDemoMode->setEnabled(false);
+    }
+    else
+    {
+        // UDP unbound — fall back to serial port device
+        dataFormatPanel.setDevice(&serialPort);
+        ui->actionDemoMode->setEnabled(!serialPort.isOpen());
     }
 }
 
@@ -532,6 +566,7 @@ void MainWindow::saveAllSettings(QSettings* settings)
 {
     saveMWSettings(settings);
     portControl.saveSettings(settings);
+    udpControl.saveSettings(settings);
     dataFormatPanel.saveSettings(settings);
     stream.saveSettings(settings);
     plotControlPanel.saveSettings(settings);
@@ -546,6 +581,7 @@ void MainWindow::loadAllSettings(QSettings* settings)
 {
     loadMWSettings(settings);
     portControl.loadSettings(settings);
+    udpControl.loadSettings(settings);
     dataFormatPanel.loadSettings(settings);
     stream.loadSettings(settings);
     plotControlPanel.loadSettings(settings);

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -35,6 +35,7 @@
 #include <qwt_plot_curve.h>
 
 #include "portcontrol.h"
+#include "udpcontrol.h"
 #include "commandpanel.h"
 #include "dataformatpanel.h"
 #include "plotcontrolpanel.h"
@@ -73,6 +74,7 @@ private:
 
     QSerialPort serialPort;
     PortControl portControl;
+    UdpControl udpControl;
 
     unsigned int numOfSamples;
 
@@ -117,6 +119,7 @@ private:
 
 private slots:
     void onPortToggled(bool open);
+    void onUdpToggled(bool bound);
     void onSourceChanged(Source* source);
     void onNumOfSamplesChanged(int value);
 

--- a/src/udpcontrol.cpp
+++ b/src/udpcontrol.cpp
@@ -1,0 +1,175 @@
+/*
+  Copyright © 2025 serialplot contributors
+
+  This file is part of serialplot.
+
+  serialplot is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  serialplot is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with serialplot.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include "udpcontrol.h"
+#include "ui_udpcontrol.h"
+
+#include <QHostAddress>
+#include <QNetworkDatagram>
+#include <QtDebug>
+
+#define SG_Udp          "Udp"
+#define SG_Udp_Address  "bindAddress"
+#define SG_Udp_Port     "port"
+
+// ---------------------------------------------------------------------------
+// UdpLineDevice
+// ---------------------------------------------------------------------------
+
+UdpLineDevice::UdpLineDevice(QObject* parent) : QIODevice(parent)
+{
+    open(QIODevice::ReadOnly);
+}
+
+void UdpLineDevice::feedData(const QByteArray& data)
+{
+    _buf.append(data);
+    emit readyRead();
+}
+
+bool UdpLineDevice::canReadLine() const
+{
+    // Qt 6's base canReadLine() only checks its internal buffer, not _buf.
+    // We must also check _buf so AsciiReader's canReadLine() loop works.
+    return _buf.contains('\n') || QIODevice::canReadLine();
+}
+
+qint64 UdpLineDevice::bytesAvailable() const
+{
+    return _buf.size() + QIODevice::bytesAvailable();
+}
+
+qint64 UdpLineDevice::readData(char* data, qint64 maxSize)
+{
+    qint64 n = qMin(maxSize, (qint64)_buf.size());
+    if (n > 0)
+    {
+        memcpy(data, _buf.constData(), n);
+        _buf.remove(0, n);
+    }
+    return n;
+}
+
+// ---------------------------------------------------------------------------
+// UdpControl
+// ---------------------------------------------------------------------------
+
+UdpControl::UdpControl(QWidget* parent) :
+    QWidget(parent),
+    ui(new Ui::UdpControl)
+{
+    ui->setupUi(this);
+
+    connect(ui->pbBind, &QPushButton::toggled, this, &UdpControl::toggleBind);
+
+    connect(&_socket, &QUdpSocket::readyRead, this, &UdpControl::onDatagramReady);
+
+    connect(&_socket, &QUdpSocket::errorOccurred,
+            [this](QAbstractSocket::SocketError)
+            {
+                ui->lbStatus->setText("Error: " + _socket.errorString());
+                ui->pbBind->setChecked(false);
+            });
+}
+
+UdpControl::~UdpControl()
+{
+    if (_socket.state() == QAbstractSocket::BoundState)
+        _socket.close();
+    delete ui;
+}
+
+QIODevice* UdpControl::device()
+{
+    return &_lineDevice;
+}
+
+bool UdpControl::isBound() const
+{
+    return _socket.state() == QAbstractSocket::BoundState;
+}
+
+void UdpControl::onDatagramReady()
+{
+    while (_socket.hasPendingDatagrams())
+    {
+        QByteArray datagram = _socket.receiveDatagram().data();
+        qDebug() << "[UDP] rx:" << datagram.trimmed();
+        _lineDevice.feedData(datagram);
+    }
+}
+
+void UdpControl::toggleBind(bool bind)
+{
+    if (bind)
+    {
+        QHostAddress addr(ui->leBindAddress->text().trimmed());
+        if (addr.isNull()) addr = QHostAddress::Any;
+        quint16 port = static_cast<quint16>(ui->sbPort->value());
+
+        if (_socket.bind(addr, port))
+        {
+            qDebug() << "[UDP] bound to" << addr.toString() << "port" << port;
+            ui->leBindAddress->setEnabled(false);
+            ui->sbPort->setEnabled(false);
+            ui->pbBind->setText("Unbind");
+            updateStatus();
+            emit socketToggled(true);
+        }
+        else
+        {
+            qDebug() << "[UDP] bind failed:" << _socket.errorString();
+            ui->lbStatus->setText("Bind failed: " + _socket.errorString());
+            ui->pbBind->setChecked(false);
+        }
+    }
+    else
+    {
+        _socket.close();
+        ui->leBindAddress->setEnabled(true);
+        ui->sbPort->setEnabled(true);
+        ui->pbBind->setText("Bind");
+        ui->lbStatus->setText("Not bound");
+        emit socketToggled(false);
+    }
+}
+
+void UdpControl::updateStatus()
+{
+    ui->lbStatus->setText(
+        QString("Bound to %1:%2")
+            .arg(_socket.localAddress().toString())
+            .arg(_socket.localPort()));
+}
+
+void UdpControl::saveSettings(QSettings* settings)
+{
+    settings->beginGroup(SG_Udp);
+    settings->setValue(SG_Udp_Address, ui->leBindAddress->text());
+    settings->setValue(SG_Udp_Port, ui->sbPort->value());
+    settings->endGroup();
+}
+
+void UdpControl::loadSettings(QSettings* settings)
+{
+    settings->beginGroup(SG_Udp);
+    ui->leBindAddress->setText(settings->value(SG_Udp_Address, "0.0.0.0").toString());
+    ui->sbPort->setValue(settings->value(SG_Udp_Port, 3000).toInt());
+    settings->endGroup();
+}

--- a/src/udpcontrol.h
+++ b/src/udpcontrol.h
@@ -1,0 +1,90 @@
+/*
+  Copyright © 2025 serialplot contributors
+
+  This file is part of serialplot.
+
+  serialplot is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  serialplot is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with serialplot.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef UDPCONTROL_H
+#define UDPCONTROL_H
+
+#include <QWidget>
+#include <QIODevice>
+#include <QUdpSocket>
+#include <QByteArray>
+#include <QSettings>
+
+namespace Ui {
+class UdpControl;
+}
+
+/**
+ * Sequential QIODevice that receives UDP datagrams and exposes them as a
+ * continuous byte stream suitable for canReadLine()/readLine()-based readers.
+ *
+ * Call feedData() whenever a new datagram arrives; the device buffers the bytes
+ * and emits readyRead() so AbstractReader::onDataReady() is triggered.
+ */
+class UdpLineDevice : public QIODevice
+{
+    Q_OBJECT
+public:
+    explicit UdpLineDevice(QObject* parent = nullptr);
+
+    void feedData(const QByteArray& data);
+
+    bool isSequential() const override { return true; }
+    bool canReadLine() const override;
+    qint64 bytesAvailable() const override;
+
+protected:
+    qint64 readData(char* data, qint64 maxSize) override;
+    qint64 writeData(const char*, qint64) override { return -1; }
+
+private:
+    QByteArray _buf;
+};
+
+class UdpControl : public QWidget
+{
+    Q_OBJECT
+
+public:
+    explicit UdpControl(QWidget* parent = nullptr);
+    ~UdpControl();
+
+    /// The line-buffered device to pass to DataFormatPanel::setDevice().
+    QIODevice* device();
+
+    bool isBound() const;
+
+    void saveSettings(QSettings* settings);
+    void loadSettings(QSettings* settings);
+
+signals:
+    /// Emitted when the socket is bound (true) or unbound (false).
+    void socketToggled(bool bound);
+
+private:
+    Ui::UdpControl* ui;
+    QUdpSocket    _socket;
+    UdpLineDevice _lineDevice;
+
+    void toggleBind(bool bind);
+    void onDatagramReady();
+    void updateStatus();
+};
+
+#endif // UDPCONTROL_H

--- a/src/udpcontrol.ui
+++ b/src/udpcontrol.ui
@@ -1,0 +1,100 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>UdpControl</class>
+ <widget class="QWidget" name="UdpControl">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>320</width>
+    <height>200</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>UDP Control</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <item>
+    <widget class="QGroupBox" name="groupBox">
+     <property name="title">
+      <string>UDP Receive</string>
+     </property>
+     <layout class="QFormLayout" name="formLayout">
+      <item row="0" column="0">
+       <widget class="QLabel" name="lbBindAddress">
+        <property name="text">
+         <string>Bind Address:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="1">
+       <widget class="QLineEdit" name="leBindAddress">
+        <property name="text">
+         <string>0.0.0.0</string>
+        </property>
+        <property name="placeholderText">
+         <string>0.0.0.0 (any interface)</string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="0">
+       <widget class="QLabel" name="lbPort">
+        <property name="text">
+         <string>Port:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="1">
+       <widget class="QSpinBox" name="sbPort">
+        <property name="minimum">
+         <number>1</number>
+        </property>
+        <property name="maximum">
+         <number>65535</number>
+        </property>
+        <property name="value">
+         <number>3000</number>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="0" colspan="2">
+       <widget class="QPushButton" name="pbBind">
+        <property name="text">
+         <string>Bind</string>
+        </property>
+        <property name="checkable">
+         <bool>true</bool>
+        </property>
+       </widget>
+      </item>
+      <item row="3" column="0" colspan="2">
+       <widget class="QLabel" name="lbStatus">
+        <property name="text">
+         <string>Not bound</string>
+        </property>
+        <property name="wordWrap">
+         <bool>true</bool>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item>
+    <spacer name="verticalSpacer">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>20</width>
+       <height>40</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>

--- a/tests/udp_sender.py
+++ b/tests/udp_sender.py
@@ -1,0 +1,100 @@
+"""
+udp_sender.py — Test script for serialplot UDP receive (issue #33)
+
+Sends simulated sensor data as UDP packets to a local port.
+Each packet is a newline-terminated ASCII line in Arduino label format:
+    label1:value1,label2:value2,...
+
+Usage:
+    python udp_sender.py [--host HOST] [--port PORT] [--rate HZ] [--mode MODE]
+
+    --host   Destination IP   (default: 127.0.0.1)
+    --port   Destination port (default: 3000)
+    --rate   Packets per second (default: 10)
+    --mode   Data mode: sine | random | counter (default: sine)
+
+Example:
+    python udp_sender.py --port 3000 --rate 20 --mode sine
+
+In serialplot:
+    1. Open the "UDP" tab
+    2. Set Bind Address to 0.0.0.0 (or 127.0.0.1) and Port to 3000
+    3. Click Bind
+    4. Switch to the "Data Format" tab and select ASCII
+    5. Channel names should auto-detect as: temp, humidity, pressure
+"""
+
+import argparse
+import math
+import random
+import socket
+import time
+
+
+def sine_values(t: float):
+    temp     = 20.0 + 5.0  * math.sin(2 * math.pi * t / 5.0)
+    humidity = 60.0 + 10.0 * math.sin(2 * math.pi * t / 8.0 + 1.0)
+    pressure = 1013.0 + 3.0 * math.sin(2 * math.pi * t / 12.0 + 2.0)
+    return temp, humidity, pressure
+
+
+def random_values(_t: float):
+    temp     = random.uniform(15.0, 35.0)
+    humidity = random.uniform(40.0, 90.0)
+    pressure = random.uniform(1005.0, 1025.0)
+    return temp, humidity, pressure
+
+
+def counter_values(t: float):
+    n = int(t * 10)
+    return float(n % 100), float(n % 50), float(n % 200)
+
+
+MODES = {
+    "sine":    sine_values,
+    "random":  random_values,
+    "counter": counter_values,
+}
+
+
+def main():
+    parser = argparse.ArgumentParser(description="serialplot UDP test sender")
+    parser.add_argument("--host", default="127.0.0.1", help="Destination IP")
+    parser.add_argument("--port", type=int, default=3000, help="Destination port")
+    parser.add_argument("--rate", type=float, default=10.0, help="Packets per second")
+    parser.add_argument("--mode", choices=MODES.keys(), default="sine", help="Data mode")
+    args = parser.parse_args()
+
+    interval = 1.0 / args.rate
+    fn = MODES[args.mode]
+
+    sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+
+    print(f"Sending UDP packets to {args.host}:{args.port} at {args.rate} Hz  (mode={args.mode})")
+    print("Press Ctrl+C to stop.\n")
+
+    start = time.monotonic()
+    count = 0
+
+    try:
+        while True:
+            t = time.monotonic() - start
+            temp, humidity, pressure = fn(t)
+
+            line = f"temp:{temp:.2f},humidity:{humidity:.1f},pressure:{pressure:.1f}\n"
+            sock.sendto(line.encode(), (args.host, args.port))
+
+            count += 1
+            if count % int(args.rate) == 0:
+                print(f"  t={t:.1f}s  {line.strip()}")
+
+            time.sleep(interval)
+
+    except KeyboardInterrupt:
+        print(f"\nSent {count} packets in {time.monotonic() - start:.1f}s")
+    finally:
+        sock.close()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Implements issue #82 — automatic channel naming from Arduino-style serial output.

### Changes

**Delimiter improvements:**
- Added `:` (colon) and `;` (semicolon) as selectable delimiters in the ASCII reader settings
- Added **Auto** mode (default) that detects the delimiter automatically from each line — tries tab, semicolon, colon, comma, space in priority order

**Arduino label auto-detection (#82):**
- When data arrives in `label:value` format (e.g. `temp:23.5,humidity:61.2`), channel names are automatically set to the detected labels
- Labels are re-applied only when they change, so there is no unnecessary model churn
- Works with the auto delimiter and all explicit delimiters

**Windows build:**
- Added `build_windows.ps1` — a one-step build script for MSYS2 ucrt64 environment
- Added `cmake/windows/FindQwt.cmake` — a Windows-compatible Qwt detection override (the original `FindQwt.cmake` uses `GET_PREREQUISITES` which crashes on Windows)

## Testing

Tested on Windows 11 with Qt 6.8.2 (MSYS2 ucrt64) and Qwt 6.3.0.

Arduino output format tested:

Channel names automatically update to `temp`, `humidity`, `pressure` on first receipt.


Windows build support

- ASCII reader: add colon, semicolon, and automatic delimiter detection
- ASCII reader: detect Arduino-style label:value fields and emit labelsReceived signal
- ChannelInfoModel: add setNames() slot to apply detected labels as channel names
- DataFormatPanel/MainWindow: wire labelsReceived through to channel name model
- Add cmake/windows/FindQwt.cmake override for Windows Qwt detection
- Add build_windows.ps1 script for MSYS2 ucrt64 Windows builds